### PR TITLE
Rspec3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 bundler_args: --without dev
 env:
-  - CI=true
+  - RSPEC_VERSION="2.12"
+  - RSPEC_VERSION=">=3.1.0"
 rvm:
   - jruby
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ env:
   - RSPEC_VERSION="2.14.0"
   - RSPEC_VERSION=">=3.1.0"
 rvm:
-  - jruby
+  - jruby-1.7.9
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 bundler_args: --without dev
 env:
-  - RSPEC_VERSION="2.12"
+  - RSPEC_VERSION="2.14.0"
   - RSPEC_VERSION=">=3.1.0"
 rvm:
   - jruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'rspec',    '>= 2.12'
+gem 'rspec',    ENV['RSPEC_VERSION'] || '>= 2.1.2'
 gem 'minitest', '>= 4.3'
 gem 'sorcerer', '>= 0.3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'rspec',    ENV['RSPEC_VERSION'] || '>= 2.1.2'
+gem 'rspec',    ENV['RSPEC_VERSION'] || '>= 2.14.0'
 gem 'minitest', '>= 4.3'
 gem 'sorcerer', '>= 0.3.7'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The rspec-given gem is the original given/when/then extension for
 RSpec. It now depends on a given_core gem for the basic functionality
 and then adds the RSpec specific code.
 
-* rspec-given now requires RSpec version 2.12 or better.
+* rspec-given now requires RSpec version 2.14.0 or better.
 
 ### Minitest/Given
 

--- a/lib/given/rspec/have_failed_212.rb
+++ b/lib/given/rspec/have_failed_212.rb
@@ -15,7 +15,7 @@ module RSpec
 
         def does_not_match?(given_proc)
           if given_proc.is_a?(::Given::Failure)
-            super(lambda { given_proc.call })
+            super(given_proc)
           else
             super(lambda { })
           end

--- a/lib/given/rspec/have_failed_212.rb
+++ b/lib/given/rspec/have_failed_212.rb
@@ -7,7 +7,7 @@ module RSpec
       class HaveFailedMatcher < RSpec::Matchers::BuiltIn::RaiseError
         def matches?(given_proc, negative_expectation = false)
           if given_proc.is_a?(::Given::Failure)
-            super
+            super(lambda { given_proc.call }, negative_expectation)
           else
             super(lambda { }, negative_expectation)
           end
@@ -15,7 +15,7 @@ module RSpec
 
         def does_not_match?(given_proc)
           if given_proc.is_a?(::Given::Failure)
-            super(given_proc)
+            super(lambda { given_proc.call })
           else
             super(lambda { })
           end

--- a/rakelib/gemspec.rake
+++ b/rakelib/gemspec.rake
@@ -48,7 +48,7 @@ EOF
     ]
 
     s.add_dependency("given_core", "= #{Given::VERSION}")
-    s.add_dependency("rspec", ">= 2.12")
+    s.add_dependency("rspec", ">= 2.14.0")
 
     s.required_ruby_version = '>= 1.9.2'
     s.license = "MIT"

--- a/spec/lib/given/failure_spec.rb
+++ b/spec/lib/given/failure_spec.rb
@@ -21,9 +21,9 @@ describe Given::Failure do
   end
 
   describe "raising error" do
-    Then { expect(failure).to raise_error(StandardError, "Oops") }
-    Then { expect(failure).to raise_error(StandardError) }
-    Then { expect(failure).to raise_error }
+    Then { expect { failure.call }.to raise_error(StandardError, "Oops") }
+    Then { expect { failure.call }.to raise_error(StandardError) }
+    Then { expect { failure.call }.to raise_error }
   end
 
   describe "== have_failed" do

--- a/spec/lib/given/have_failed_spec.rb
+++ b/spec/lib/given/have_failed_spec.rb
@@ -39,12 +39,19 @@ module HaveFailedSpec
       Then { expect { expect(result).to have_failed(DifferentError) }.to raise_error(ExpectationError) }
     end
 
-    context "with a pending exception" do
-      def pending_error
+    context "with a skip exception" do
+      # `skip` replaces old `pending` behavior in RSpec < 3
+      #  Details: http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3
+      def skip_error
         RSpec::Given::Framework.new.pending_error
       end
-      When(:result) { fail pending_error, "Required pending in example ... please ignore" }
-      Then { Given.fail_with "This example should have been pending" }
+      When(:result) { fail skip_error, "Used `skip` in example ... please ignore" }
+      Then { Given.fail_with "This example should have been skipped" }
+    end
+
+    context "with a pending invocation" do
+      When(:result) { pending "Forcing a pending in example ... please ignore" }
+      Then { Given.fail_with "This example should have been regarded as pending" }
     end
 
     context "with a non-failure" do

--- a/spec/lib/given/have_failed_spec.rb
+++ b/spec/lib/given/have_failed_spec.rb
@@ -9,7 +9,7 @@ module HaveFailedSpec
     context "with a failure" do
       When(:result) { fail CustomError, "Ouch" }
 
-      Then { expect(result).to raise_error(CustomError, "Ouch") }
+      Then { expect { result.call }.to raise_error(CustomError, "Ouch") }
       Then { expect(result).to have_failed(CustomError, "Ouch") }
       Then { expect(result).to have_raised(CustomError, "Ouch") }
 
@@ -23,10 +23,10 @@ module HaveFailedSpec
     context "with a standard failure" do
       When(:result) { fail "Ouch" }
 
-      Then { expect(result).to raise_error(StandardError, "Ouch") }
-      Then { expect(result).to raise_error(StandardError, /^O/) }
-      Then { expect(result).to raise_error(StandardError) }
-      Then { expect(result).to raise_error }
+      Then { expect { result.call }.to raise_error(StandardError, "Ouch") }
+      Then { expect { result.call }.to raise_error(StandardError, /^O/) }
+      Then { expect { result.call }.to raise_error(StandardError) }
+      Then { expect { result.call }.to raise_error }
 
       Then { expect(result).to have_failed(StandardError, "Ouch") }
       Then { expect(result).to have_failed(StandardError, /^O/) }


### PR DESCRIPTION
There are currently 19 failing specs on master when running the latest versions of rspec. 
- [x] 9 specs fixed by @ronen's https://github.com/jimweirich/rspec-given/pull/43
- [x] 2 specs fixed by reverting the part of the above change (`does_not_match?` was inadvertently wrapping `Given::Failure` objects)
- [x] 8 specs fixed by passing `expect` a block when paired with the `raise_error` matcher
- [x] fix pending specs 850aa13b886399f4ff1b1f258a512f1c27c25660
- [x] Open an issue for latest jruby issues #2
- [x] change minimum supported version from rspec 2.12.0 to 2.14.1
- [x] Set up a matrix for travis that tests rspec 2 as well as 3 (Env variable referenced from the gemfile perhaps?)

Before merging, it may make sense to attempt a travis build matrix that maintains rspec 2 support.
