### PR TITLE
Change the way minitest-given is loaded for AR models and non-AR mode…

### DIFF
--- a/lib/given/minitest/configure.rb
+++ b/lib/given/minitest/configure.rb
@@ -1,6 +1,10 @@
 
 # Configure Minitest to use the Given extensions.
-
+if defined?(ActiveSupport::TestCase)
+  ActiveSupport::TestCase.send(:extend, Given::ClassExtensions)
+  ActiveSupport::TestCase.send(:include, Given::FailureMethod)
+  ActiveSupport::TestCase.send(:include, Given::InstanceExtensions)
+end
 Minitest::Spec.send(:extend,  Given::ClassExtensions)
 Minitest::Spec.send(:include, Given::FailureMethod)
 Minitest::Spec.send(:include, Given::InstanceExtensions)

--- a/lib/minitest/given.rb
+++ b/lib/minitest/given.rb
@@ -1,15 +1,2 @@
 require 'minitest/spec'
-
-if defined?(ActiveSupport::TestCase)
-  Minitest::Spec.tap do |original_spec|
-    Minitest.send(:remove_const, :Spec)
-    Minitest::Spec = ActiveSupport::TestCase
-
-    require 'given/minitest/all'
-
-    Minitest.send(:remove_const, :Spec)
-    Minitest::Spec = original_spec
-  end
-else
-  require 'given/minitest/all'
-end
+require 'given/minitest/all'


### PR DESCRIPTION
Change the way minitest-given is loaded for AR models and non-AR models so it works for both at the same time.
