### PR TITLE
Make rspec-given work for both TestCase and Minitest::Spec together.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,9 +62,10 @@ end
 EXAMPLES = FileList['examples/**/*_spec.rb', 'examples/use_assertions.rb'].
   exclude('examples/failing/*.rb').
   exclude('examples/minitest/*.rb').
+  exclude('examples/minitest-rails/*.rb').
   exclude('examples/integration/failing/*.rb')
 
-MT_EXAMPLES = FileList['examples/minitest/**/*_spec.rb']
+MT_EXAMPLES = FileList['examples/minitest-rails/**/*_spec.rb', 'examples/minitest/**/*_spec.rb']
 
 unless Given::NATURAL_ASSERTIONS_SUPPORTED
   EXAMPLES.exclude("examples/stack/*.rb")

--- a/examples/active_support_helper.rb
+++ b/examples/active_support_helper.rb
@@ -1,0 +1,30 @@
+module ActiveRecord
+  class Base
+  end
+end
+
+module ActiveSupport
+  class TestCase < Minitest::Test
+    def setup(*args, &block)
+    end
+
+    # Remove describe method if present
+    class << self
+      remove_method :describe
+    end if self.respond_to?(:describe) &&
+        self.method(:describe).owner == ActiveSupport::TestCase
+
+    # Add spec DSL
+    extend ::Minitest::Spec::DSL
+
+    if defined?(ActiveRecord::Base)
+      # Use AS::TestCase for the base class when describing a model
+      register_spec_type(self) do |desc|
+        desc < ActiveRecord::Base if desc.is_a?(Class)
+      end
+    end
+    register_spec_type(self) do |desc, *addl|
+      addl.include? :model
+    end
+  end
+end

--- a/examples/active_support_helper.rb
+++ b/examples/active_support_helper.rb
@@ -1,28 +1,8 @@
-module ActiveRecord
-  class Base
-  end
-end
-
 module ActiveSupport
   class TestCase < Minitest::Test
-    def setup(*args, &block)
-    end
-
-    # Remove describe method if present
-    class << self
-      remove_method :describe
-    end if self.respond_to?(:describe) &&
-        self.method(:describe).owner == ActiveSupport::TestCase
-
     # Add spec DSL
     extend ::Minitest::Spec::DSL
 
-    if defined?(ActiveRecord::Base)
-      # Use AS::TestCase for the base class when describing a model
-      register_spec_type(self) do |desc|
-        desc < ActiveRecord::Base if desc.is_a?(Class)
-      end
-    end
     register_spec_type(self) do |desc, *addl|
       addl.include? :model
     end

--- a/examples/example_helper.rb
+++ b/examples/example_helper.rb
@@ -5,6 +5,7 @@ if defined?(RSpec)
   require 'spec_helper'
 else
   require 'minitest/autorun'
+  require 'active_support_helper'
   require 'minitest/given'
   require 'minitest_helper'
 end

--- a/examples/minitest-rails/test_case_spec.rb
+++ b/examples/minitest-rails/test_case_spec.rb
@@ -1,0 +1,35 @@
+require 'minitest/autorun'
+require 'active_support_helper'
+require 'minitest/given'
+require 'example_helper'
+
+
+describe ActiveSupport::TestCase, :model do
+  Given(:info) { [] }
+  Given { info << "outer1" }
+  Given { info << "outer2" }
+
+  context "using a when without result" do
+    When { info << "when" }
+
+    context "inner with When" do
+      Given { info << "inner1" }
+      Given { info << "inner2" }
+      Then { given_assert_equal ["outer1", "outer2", "inner1", "inner2", "when"], info }
+
+      context "using a nested When" do
+        When { info << "when2" }
+        Then { given_assert_equal ["outer1", "outer2", "inner1", "inner2", "when", "when2"], info}
+      end
+
+      context "using two nested When" do
+        When { info << "when2a" }
+        When { info << "when2b" }
+        Then {
+          given_assert_equal ["outer1", "outer2", "inner1", "inner2", "when", "when2a", "when2b"], info
+        }
+      end
+    end
+  end
+end
+

--- a/examples/minitest-rails/test_case_spec.rb
+++ b/examples/minitest-rails/test_case_spec.rb
@@ -25,9 +25,7 @@ describe ActiveSupport::TestCase, :model do
       context "using two nested When" do
         When { info << "when2a" }
         When { info << "when2b" }
-        Then {
-          given_assert_equal ["outer1", "outer2", "inner1", "inner2", "when", "when2a", "when2b"], info
-        }
+        Then { given_assert_equal ["outer1", "outer2", "inner1", "inner2", "when", "when2a", "when2b"], info }
       end
     end
   end

--- a/examples/minitest_helper.rb
+++ b/examples/minitest_helper.rb
@@ -35,4 +35,5 @@ module NaturalAssertionControl
 end
 
 Minitest::Spec.send(:include, GivenAssertions)
+Minitest::Test.send(:include, GivenAssertions)
 include NaturalAssertionControl

--- a/lib/given/extensions.rb
+++ b/lib/given/extensions.rb
@@ -158,16 +158,6 @@ module Given
       @_Gvn_and_blocks ||= []
     end
 
-    # Lazy accessor for Given's before blocks
-    def _Gvn_before_blocks
-      @_Gvn_before_blocks ||= []
-    end
-
-    # Define a Given style before block
-    def _Gvn_before(&block)
-      _Gvn_before_blocks << block
-    end
-
     # Context information ofr the current describe/context block.
     def _Gvn_context_info       # :nodoc:
       @_Gvn_context_info ||= {}

--- a/lib/given/extensions.rb
+++ b/lib/given/extensions.rb
@@ -158,6 +158,16 @@ module Given
       @_Gvn_and_blocks ||= []
     end
 
+    # Lazy accessor for Given's before blocks
+    def _Gvn_before_blocks
+      @_Gvn_before_blocks ||= []
+    end
+
+    # Define a Given style before block
+    def _Gvn_before(&block)
+      _Gvn_before_blocks << block
+    end
+
     # Context information ofr the current describe/context block.
     def _Gvn_context_info       # :nodoc:
       @_Gvn_context_info ||= {}

--- a/lib/given/minitest/before_extension.rb
+++ b/lib/given/minitest/before_extension.rb
@@ -25,23 +25,26 @@ module Minitest
   end
 end
 
-module ActiveSupport
-  class TestCase
+if defined?(ActiveSupport::TestCase)
+  module ActiveSupport
+    class TestCase
 
-    # Redefine setup to trigger before chains
-    alias original_setup_without_given setup
-    def setup
-      original_setup_without_given
-      _gvn_establish_befores
-    end
+      # Redefine setup to trigger before chains
+      alias original_setup_without_given setup
 
-    # Establish the before blocks
-    def _gvn_establish_befores
-      return if defined?(@_gvn_ran_befores) && @_gvn_ran_befores
-      @_gvn_ran_befores = true
-      _gvn_contexts.each do |context|
-        context._Gvn_before_blocks.each do |before_block|
-          instance_eval(&before_block)
+      def setup
+        original_setup_without_given
+        _gvn_establish_befores
+      end
+
+      # Establish the before blocks
+      def _gvn_establish_befores
+        return if defined?(@_gvn_ran_befores) && @_gvn_ran_befores
+        @_gvn_ran_befores = true
+        _gvn_contexts.each do |context|
+          context._Gvn_before_blocks.each do |before_block|
+            instance_eval(&before_block)
+          end
         end
       end
     end

--- a/lib/given/minitest/before_extension.rb
+++ b/lib/given/minitest/before_extension.rb
@@ -15,44 +15,8 @@ module Given
         _Gvn_before_blocks << block
       end
     end
-  end
-end
 
-module Minitest
-  class Spec
-
-    # Redefine setup to trigger before chains
-    alias original_setup_without_given setup
-    def setup
-      original_setup_without_given
-      _gvn_establish_befores
-    end
-
-    # Establish the before blocks
-    def _gvn_establish_befores
-      return if defined?(@_gvn_ran_befores) && @_gvn_ran_befores
-      @_gvn_ran_befores = true
-      _gvn_contexts.each do |context|
-        context._Gvn_before_blocks.each do |before_block|
-          instance_eval(&before_block)
-        end
-      end
-    end
-  end
-end
-
-if defined?(ActiveSupport::TestCase)
-  module ActiveSupport
-    class TestCase
-
-      # Redefine setup to trigger before chains
-      alias original_setup_without_given setup
-
-      def setup
-        original_setup_without_given
-        _gvn_establish_befores
-      end
-
+    module InstanceExtensions
       # Establish the before blocks
       def _gvn_establish_befores
         return if defined?(@_gvn_ran_befores) && @_gvn_ran_befores
@@ -62,6 +26,30 @@ if defined?(ActiveSupport::TestCase)
             instance_eval(&before_block)
           end
         end
+      end
+    end
+  end
+end
+
+module Minitest
+  class Spec
+    # Redefine setup to trigger before chains
+    alias original_setup_without_given setup
+    def setup
+      original_setup_without_given
+      _gvn_establish_befores
+    end
+  end
+end
+
+if defined?(ActiveSupport::TestCase)
+  module ActiveSupport
+    class TestCase
+      # Redefine setup to trigger before chains
+      alias original_setup_without_given setup
+      def setup
+        original_setup_without_given
+        _gvn_establish_befores
       end
     end
   end

--- a/lib/given/minitest/before_extension.rb
+++ b/lib/given/minitest/before_extension.rb
@@ -2,6 +2,22 @@
 # The before blocks defined in Minitest are inadequate for our use.
 # This before_extension file allows us to use real before blocks.
 
+module Given
+  module MiniTest
+    module ClassExtensions
+      # Lazy accessor for Given's before blocks
+      def _Gvn_before_blocks
+        @_Gvn_before_blocks ||= []
+      end
+
+      # Define a Given style before block
+      def _Gvn_before(&block)
+        _Gvn_before_blocks << block
+      end
+    end
+  end
+end
+
 module Minitest
   class Spec
 

--- a/lib/given/minitest/before_extension.rb
+++ b/lib/given/minitest/before_extension.rb
@@ -22,15 +22,28 @@ module Minitest
         end
       end
     end
+  end
+end
 
-    # Lazy accessor for Given's before blocks
-    def self._Gvn_before_blocks
-      @_Gvn_before_blocks ||= []
+module ActiveSupport
+  class TestCase
+
+    # Redefine setup to trigger before chains
+    alias original_setup_without_given setup
+    def setup
+      original_setup_without_given
+      _gvn_establish_befores
     end
 
-    # Define a Given style before block
-    def self._Gvn_before(&block)
-      _Gvn_before_blocks << block
+    # Establish the before blocks
+    def _gvn_establish_befores
+      return if defined?(@_gvn_ran_befores) && @_gvn_ran_befores
+      @_gvn_ran_befores = true
+      _gvn_contexts.each do |context|
+        context._Gvn_before_blocks.each do |before_block|
+          instance_eval(&before_block)
+        end
+      end
     end
   end
 end

--- a/lib/given/minitest/configure.rb
+++ b/lib/given/minitest/configure.rb
@@ -1,6 +1,10 @@
 
 # Configure Minitest to use the Given extensions.
-
+if defined?(ActiveSupport::TestCase)
+  ActiveSupport::TestCase.send(:extend, Given::ClassExtensions)
+  ActiveSupport::TestCase.send(:include, Given::FailureMethod)
+  ActiveSupport::TestCase.send(:include, Given::InstanceExtensions)
+end
 Minitest::Spec.send(:extend,  Given::ClassExtensions)
 Minitest::Spec.send(:include, Given::FailureMethod)
 Minitest::Spec.send(:include, Given::InstanceExtensions)

--- a/lib/given/minitest/configure.rb
+++ b/lib/given/minitest/configure.rb
@@ -1,10 +1,10 @@
-
-# Configure Minitest to use the Given extensions.
+# Configure ActiveSupprt::TestCase to use the Given extensions.
 if defined?(ActiveSupport::TestCase)
   ActiveSupport::TestCase.send(:extend, Given::ClassExtensions)
   ActiveSupport::TestCase.send(:include, Given::FailureMethod)
   ActiveSupport::TestCase.send(:include, Given::InstanceExtensions)
 end
+# Configure Minitest to use the Given extensions.
 Minitest::Spec.send(:extend,  Given::ClassExtensions)
 Minitest::Spec.send(:include, Given::FailureMethod)
 Minitest::Spec.send(:include, Given::InstanceExtensions)

--- a/lib/given/minitest/configure.rb
+++ b/lib/given/minitest/configure.rb
@@ -4,10 +4,12 @@ if defined?(ActiveSupport::TestCase)
   ActiveSupport::TestCase.send(:extend, Given::MiniTest::ClassExtensions)
   ActiveSupport::TestCase.send(:include, Given::FailureMethod)
   ActiveSupport::TestCase.send(:include, Given::InstanceExtensions)
+  ActiveSupport::TestCase.send(:include, Given::MiniTest::InstanceExtensions)
 end
 # Configure Minitest to use the Given extensions.
 Minitest::Spec.send(:extend,  Given::ClassExtensions)
 Minitest::Spec.send(:extend, Given::MiniTest::ClassExtensions)
 Minitest::Spec.send(:include, Given::FailureMethod)
 Minitest::Spec.send(:include, Given::InstanceExtensions)
+Minitest::Spec.send(:include, Given::MiniTest::InstanceExtensions)
 Given.use_natural_assertions if Given::NATURAL_ASSERTIONS_SUPPORTED

--- a/lib/given/minitest/configure.rb
+++ b/lib/given/minitest/configure.rb
@@ -1,11 +1,13 @@
 # Configure ActiveSupprt::TestCase to use the Given extensions.
 if defined?(ActiveSupport::TestCase)
   ActiveSupport::TestCase.send(:extend, Given::ClassExtensions)
+  ActiveSupport::TestCase.send(:extend, Given::MiniTest::ClassExtensions)
   ActiveSupport::TestCase.send(:include, Given::FailureMethod)
   ActiveSupport::TestCase.send(:include, Given::InstanceExtensions)
 end
 # Configure Minitest to use the Given extensions.
 Minitest::Spec.send(:extend,  Given::ClassExtensions)
+Minitest::Spec.send(:extend, Given::MiniTest::ClassExtensions)
 Minitest::Spec.send(:include, Given::FailureMethod)
 Minitest::Spec.send(:include, Given::InstanceExtensions)
 Given.use_natural_assertions if Given::NATURAL_ASSERTIONS_SUPPORTED

--- a/lib/minitest/given.rb
+++ b/lib/minitest/given.rb
@@ -1,15 +1,2 @@
 require 'minitest/spec'
-
-if defined?(ActiveSupport::TestCase)
-  Minitest::Spec.tap do |original_spec|
-    Minitest.send(:remove_const, :Spec)
-    Minitest::Spec = ActiveSupport::TestCase
-
-    require 'given/minitest/all'
-
-    Minitest.send(:remove_const, :Spec)
-    Minitest::Spec = original_spec
-  end
-else
-  require 'given/minitest/all'
-end
+require 'given/minitest/all'


### PR DESCRIPTION
Due to the way Minitest::Spec is mixed into TestCase, TestCase has to also be extended in a similar way that MinitestSpec is for rspec-given to work when for example ActiveRecord specs exist alongside non-ActiveRecord (plain PORO) specs.
