### PR TITLE
Accept user-defined rspec metadata on Then clauses

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,12 @@ should use an empty _Then_ clause, like this:
     Then { }
 ```
 
+A _Then_ clause accepts arguments for user-defined rspec metadata:
+
+```ruby
+    Then(:zippy, :foo => 17) { ... }
+```
+
 #### Then examples:
 
 ```ruby

--- a/lib/given/extensions.rb
+++ b/lib/given/extensions.rb
@@ -247,11 +247,13 @@ module Given
     # :call-seq:
     #   Then { ... assertion ... }
     #
-    def Then(opts={}, &block)
-      on_eval = opts.fetch(:on_eval, "_gvn_then")
+    def Then(*metadata, &block)
+      opts = metadata.last
+      opts = {} unless opts.is_a? Hash
+      on_eval = opts.delete(:on_eval) || "_gvn_then"
       file, line = Given.location_of(block)
       description = _Gvn_lines.line(file, line) unless Given.source_caching_disabled
-      cmd = description ? "it(description)" : "specify"
+      cmd = description ? "it(description, *metadata)" : "specify(*metadata)"
       eval %{#{cmd} do #{on_eval}(&block) end}, binding, file, line
       _Gvn_context_info[:then_defined] = true
     end

--- a/spec/lib/given/extensions_spec.rb
+++ b/spec/lib/given/extensions_spec.rb
@@ -180,6 +180,16 @@ describe Given::ClassExtensions do
     Then { result == :ok }
   end
 
+  if RSpec::Version::STRING.start_with? "2"
+    describe "Then with metadata" do
+      Then(:opt => :val) { expect(example.metadata[:opt]).to eq(:val) }
+    end
+  else
+    describe "Then with metadata" do
+      Then(:key, :opt => :val) { expect([RSpec.current_example.metadata[:key], RSpec.current_example.metadata[:opt]]).to eq([true, :val]) }
+    end
+  end
+
   describe "And" do
     Given { trace << :given }
     Then { trace << :then }


### PR DESCRIPTION
This lets you define metadata on a Then clause same as you can on an "it" statement.  E.g., to use [rspec-retry](https://github.com/NoRedInk/rspec-retry), you could do:

``` ruby
Then(retry: 3) { ...my flaky expectation...}
```
