### PR TITLE
Add natural assertions support for JRuby 1.7.10 and higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ env:
   - RSPEC_VERSION="2.14.0"
   - RSPEC_VERSION=">=3.1.0"
 rvm:
-  - jruby-1.7.9
+  - jruby
   - 1.9.3
   - 2.0.0

--- a/lib/given/module_methods.rb
+++ b/lib/given/module_methods.rb
@@ -3,7 +3,7 @@ module Given
   # Does this platform support natural assertions?
   RBX_IN_USE = (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx')
   JRUBY_IN_USE = defined?(JRUBY_VERSION)
-  OLD_JRUBY_IN_USE = JRUBY_IN_USE && (JRUBY_VERSION < '1.7.5')
+  OLD_JRUBY_IN_USE = JRUBY_IN_USE && (Gem::Version.new(JRUBY_VERSION) < Gem::Version.new('1.7.5'))
 
   NATURAL_ASSERTIONS_SUPPORTED = ! (OLD_JRUBY_IN_USE || RBX_IN_USE)
 


### PR DESCRIPTION
Updated code that compares the version of JRUBY to '1.7.5' to determine
if natural assertions are supported. Fixes #2.
