### PR TITLE
add support for Rubinius

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,12 +760,13 @@ _expect_.
 
 Given uses the Ripper library to parse the source lines and failing
 conditions to find all the sub-expression values upon a failure.
-Currently Ripper is not supported on Rubinius and versions of JRuby
-prior to JRuby-1.7.5.
 
-If you want to use a version of Ruby that does not support Ripper,
-then natural assertions will disabled. In addition, you should also
-disable source caching in the configuration (see the configuration
+If Ripper is not available, like on Rubinius and versions of JRuby prior to
+JRuby-1.7.5, detailed explanations of failures for natural assertions won't be
+available.  Natural assertions will still work, though.
+
+If you want to use a version of Ruby that does not support Ripper, then you
+should disable source caching in the configuration (see the configuration
 section below).
 
 ### Non-Spec Assertions
@@ -869,6 +870,11 @@ rspec-given, minitest-given and given_core are available under the MIT
 License. See the MIT-LICENSE file in the source distribution.
 
 # History
+
+* next release
+
+  * Natural assertions now work on Rubinius and older versions of JRuby (see [#15](https://github.com/rspec-given/rspec-given/issues/15))
+    * WARNING: On these platforms, detailed failure explanations aren't available and source code snippets of Then clauses will only show the first line.
 
 * Version 3.7.1
 

--- a/Rakefile
+++ b/Rakefile
@@ -67,10 +67,6 @@ EXAMPLES = FileList['examples/**/*_spec.rb', 'examples/use_assertions.rb'].
 
 MT_EXAMPLES = FileList['examples/minitest-rails/**/*_spec.rb', 'examples/minitest/**/*_spec.rb']
 
-unless Given::NATURAL_ASSERTIONS_SUPPORTED
-  EXAMPLES.exclude("examples/stack/*.rb")
-end
-
 FAILING_EXAMPLES = FileList['examples/failing/**/*_spec.rb']
 
 desc "Run the RSpec specs and examples"

--- a/examples/integration/failing_messages_spec.rb
+++ b/examples/integration/failing_messages_spec.rb
@@ -2,7 +2,6 @@ require 'example_helper'
 require 'open3'
 
 describe "Failing Messages" do
-  use_natural_assertions_if_supported
 
   IOS = Struct.new(:out, :err)
 

--- a/examples/integration/then_spec.rb
+++ b/examples/integration/then_spec.rb
@@ -11,11 +11,9 @@ end
 
 describe "Then" do
   context "empty thens with natural assertions" do
-    use_natural_assertions_if_supported
     Then { }
   end
   context "thens to_bool/true will pass" do
-    use_natural_assertions_if_supported
     Then { ToBool.new(true) }
   end
 end

--- a/examples/minitest_helper.rb
+++ b/examples/minitest_helper.rb
@@ -22,18 +22,5 @@ module GivenAssertions
   end
 end
 
-module NaturalAssertionControl
-  def use_natural_assertions_if_supported(enabled=true)
-    if enabled && ! Given::NATURAL_ASSERTIONS_SUPPORTED
-      Given {
-        skip "Natural assertions are not supported in JRuby"
-      }
-    else
-      use_natural_assertions(enabled)
-    end
-  end
-end
-
 Minitest::Spec.send(:include, GivenAssertions)
 Minitest::Test.send(:include, GivenAssertions)
-include NaturalAssertionControl

--- a/examples/use_assertions.rb
+++ b/examples/use_assertions.rb
@@ -1,47 +1,44 @@
 require 'given/module_methods'
 
-if Given::NATURAL_ASSERTIONS_SUPPORTED
+require 'given/assertions'
+require 'given/fuzzy_number'
 
-  require 'given/assertions'
-  require 'given/fuzzy_number'
+include Given::Assertions
+include Given::Fuzzy
 
-  include Given::Assertions
-  include Given::Fuzzy
-
-  def sqrt(n)
-    Precondition { n >= 0 }
-    result = Math.sqrt(n)
-    Postcondition { result ** 2 == about(n) }
-    result
-  end
-
-  def sqrt_bad_postcondition(n)
-    Precondition { n >= 0 }
-    result = Math.sqrt(n)
-    Postcondition { result ** 2 == about(n+1) }
-    result
-  end
-
-  def use_assert(n)
-    Assert { n == 1 }
-  end
-
-  def should_fail
-    begin
-      yield
-      fail "Expected error"
-    rescue Given::Assertions::AssertError => ex
-      true
-    end
-  end
-
-  sqrt(1)
-  sqrt(2)
-  sqrt(0)
-
-  should_fail { sqrt(-1) }
-  should_fail { sqrt_bad_postcondition(1) }
-
-  use_assert(1)
-  should_fail { use_assert(0) }
+def sqrt(n)
+  Precondition { n >= 0 }
+  result = Math.sqrt(n)
+  Postcondition { result ** 2 == about(n) }
+  result
 end
+
+def sqrt_bad_postcondition(n)
+  Precondition { n >= 0 }
+  result = Math.sqrt(n)
+  Postcondition { result ** 2 == about(n+1) }
+  result
+end
+
+def use_assert(n)
+  Assert { n == 1 }
+end
+
+def should_fail
+  begin
+    yield
+    fail "Expected error"
+  rescue Given::Assertions::AssertError => ex
+    true
+  end
+end
+
+sqrt(1)
+sqrt(2)
+sqrt(0)
+
+should_fail { sqrt(-1) }
+should_fail { sqrt_bad_postcondition(1) }
+
+use_assert(1)
+should_fail { use_assert(0) }

--- a/lib/given/line_extractor.rb
+++ b/lib/given/line_extractor.rb
@@ -1,6 +1,16 @@
-require 'ripper'
-require 'sorcerer'
+begin
+  require 'ripper'
+  require 'sorcerer'
+rescue LoadError
+  # NOTE: on Rubinius or old JRuby, Ripper isn't available
+  warn <<-WARNING
+rspec-given: WARNING: Sorcerer is not available, so in case of a failing Then
+clause, only its FIRST LINE of source will be printed, no matter how many
+lines it actually spans.
+  WARNING
+end
 require 'given/file_cache'
+
 
 module Given
   class LineExtractor
@@ -21,6 +31,7 @@ module Given
 
     def extract_lines_from(lines, line_index)
       result = lines[line_index]
+      return result if ! defined?(::Sorcerer)
       while result && incomplete?(result)
         line_index += 1
         result << lines[line_index]

--- a/lib/given/minitest/configure.rb
+++ b/lib/given/minitest/configure.rb
@@ -12,4 +12,4 @@ Minitest::Spec.send(:extend, Given::MiniTest::ClassExtensions)
 Minitest::Spec.send(:include, Given::FailureMethod)
 Minitest::Spec.send(:include, Given::InstanceExtensions)
 Minitest::Spec.send(:include, Given::MiniTest::InstanceExtensions)
-Given.use_natural_assertions if Given::NATURAL_ASSERTIONS_SUPPORTED
+Given.use_natural_assertions

--- a/lib/given/module_methods.rb
+++ b/lib/given/module_methods.rb
@@ -37,7 +37,7 @@ module Given
     @natural_assertions_enabled
   end
 
-  # Is is OK to use natural assertions on this platform.
+  # It is OK to use natural assertions on this platform.
   #
   # An error is raised if the the platform does not support natural
   # assertions and the flag is attempting to enable them.

--- a/lib/given/module_methods.rb
+++ b/lib/given/module_methods.rb
@@ -1,11 +1,5 @@
 
 module Given
-  # Does this platform support natural assertions?
-  RBX_IN_USE = (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx')
-  JRUBY_IN_USE = defined?(JRUBY_VERSION)
-  OLD_JRUBY_IN_USE = JRUBY_IN_USE && (JRUBY_VERSION < '1.7.5')
-
-  NATURAL_ASSERTIONS_SUPPORTED = true
 
   def self.framework
     @_gvn_framework
@@ -41,10 +35,9 @@ module Given
   #
   # An error is raised if the the platform does not support natural
   # assertions and the flag is attempting to enable them.
+  #
+  # NOTE: Deprecated. Natural assertions are supported on all platforms now.
   def self.ok_to_use_natural_assertions(enabled)
-    if enabled && ! NATURAL_ASSERTIONS_SUPPORTED
-      fail ArgumentError, "Natural Assertions are disabled for JRuby"
-    end
   end
 
   # Return file and line number where the block is defined.

--- a/lib/given/module_methods.rb
+++ b/lib/given/module_methods.rb
@@ -5,7 +5,7 @@ module Given
   JRUBY_IN_USE = defined?(JRUBY_VERSION)
   OLD_JRUBY_IN_USE = JRUBY_IN_USE && (JRUBY_VERSION < '1.7.5')
 
-  NATURAL_ASSERTIONS_SUPPORTED = ! (OLD_JRUBY_IN_USE || RBX_IN_USE)
+  NATURAL_ASSERTIONS_SUPPORTED = true
 
   def self.framework
     @_gvn_framework

--- a/lib/given/natural_assertion.rb
+++ b/lib/given/natural_assertion.rb
@@ -2,9 +2,15 @@ require 'given/module_methods'
 require 'given/evaluator'
 require 'given/binary_operation'
 
-if Given::NATURAL_ASSERTIONS_SUPPORTED
+begin
   require 'ripper'
   require 'sorcerer'
+rescue LoadError
+  # NOTE: on Rubinius or old JRuby, Ripper isn't available
+  warn <<-WARNING
+rspec-given: WARNING: Ripper is not available, so detailed failure
+explanations of natural assertions WILL NOT printed.
+  WARNING
 end
 
 module Given
@@ -23,15 +29,20 @@ module Given
     VOID_SEXP = [:void_stmt]
 
     def has_content?
+      return true if ! defined?(::Ripper)
       assertion_sexp != VOID_SEXP
     end
 
     def message
       @output = "#{@clause_type} expression failed at #{source_line}\n"
-      @output << "Failing expression: #{source.strip}\n" if @clause_type != "Then"
-      explain_failure
-      display_pairs(expression_value_pairs)
-      @output << "\n"
+      if defined?(::Ripper)
+        @output << "Failing expression: #{source.strip}\n" if @clause_type != "Then"
+        explain_failure
+        display_pairs(expression_value_pairs)
+        @output << "\n"
+      else
+        @output << "Failing expression (possibly truncated): #{source.strip}\n"
+      end
       @output
     end
 

--- a/lib/given/rspec/all.rb
+++ b/lib/given/rspec/all.rb
@@ -6,10 +6,8 @@ module RSpec
   end
 end
 
-if Given::NATURAL_ASSERTIONS_SUPPORTED
-  require 'given/rspec/monkey'
-  raise "Unsupported version of RSpec (#{RSpec::Version::STRING}), unable to detect assertions" unless RSpec::Given::MONKEY
-end
+require 'given/rspec/monkey'
+raise "Unsupported version of RSpec (#{RSpec::Version::STRING}), unable to detect assertions" unless RSpec::Given::MONKEY
 
 require 'given/rspec/have_failed'
 require 'given/rspec/before_extensions'

--- a/lib/given/rspec/configure.rb
+++ b/lib/given/rspec/configure.rb
@@ -15,6 +15,6 @@ RSpec.configure do |c|
     c.backtrace_clean_patterns << /lib\/rspec\/given/
   end
 
-  Given.use_natural_assertions if Given::NATURAL_ASSERTIONS_SUPPORTED
+  Given.use_natural_assertions
   Given.source_caching_disabled = false
 end

--- a/rspec-given.gemspec
+++ b/rspec-given.gemspec
@@ -1,0 +1,153 @@
+--- !ruby/object:Gem::Specification
+name: rspec-given
+version: !ruby/object:Gem::Version
+  version: 3.7.1
+platform: ruby
+authors:
+- Jim Weirich
+autorequire: 
+bindir: bin
+cert_chain: []
+date: 2015-12-23 00:00:00.000000000 Z
+dependencies:
+- !ruby/object:Gem::Dependency
+  name: given_core
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - '='
+      - !ruby/object:Gem::Version
+        version: 3.7.1
+  type: :runtime
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - '='
+      - !ruby/object:Gem::Version
+        version: 3.7.1
+- !ruby/object:Gem::Dependency
+  name: rspec
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: 2.14.0
+  type: :runtime
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: 2.14.0
+description: |
+  Given is an RSpec extension that allows the use of Given/When/Then
+  terminology when defining specifications.
+email: jim.weirich@gmail.com
+executables: []
+extensions: []
+extra_rdoc_files: []
+files:
+- Gemfile
+- MIT-LICENSE
+- README.md
+- Rakefile
+- TODO
+- doc
+- doc/article
+- doc/article/custom_error_messages.md
+- doc/main.rdoc
+- examples
+- examples/active_support_helper.rb
+- examples/example_helper.rb
+- examples/failing
+- examples/failing/natural_failing_spec.rb
+- examples/failing/sample_spec.rb
+- examples/integration
+- examples/integration/and_spec.rb
+- examples/integration/failing
+- examples/integration/failing/eval_subexpression_spec.rb
+- examples/integration/failing/module_nesting_spec.rb
+- examples/integration/failing/oddly_formatted_then.rb
+- examples/integration/failing/to_bool_returns_false.rb
+- examples/integration/failing/undefined_method_spec.rb
+- examples/integration/failing_messages_spec.rb
+- examples/integration/focused_line_spec.rb
+- examples/integration/given_spec.rb
+- examples/integration/invariant_spec.rb
+- examples/integration/then_spec.rb
+- examples/loader.rb
+- examples/minitest
+- examples/minitest-rails
+- examples/minitest-rails/test_case_spec.rb
+- examples/minitest/assert_raises_spec.rb
+- examples/minitest_helper.rb
+- examples/other
+- examples/other/line_example.rb
+- examples/stack
+- examples/stack/stack.rb
+- examples/stack/stack_spec.rb
+- examples/stack/stack_spec1.rb
+- examples/use_assertions.rb
+- lib
+- lib/given.rb
+- lib/rspec-given.rb
+- lib/rspec/given.rb
+- rakelib
+- rakelib/bundler_fix.rb
+- rakelib/gemspec.rake
+- rakelib/metrics.rake
+- rakelib/preview.rake
+- spec
+- spec/lib/given/assertions_spec.rb
+- spec/lib/given/binary_operation_spec.rb
+- spec/lib/given/evaluator_spec.rb
+- spec/lib/given/ext/numeric_spec.rb
+- spec/lib/given/ext/numeric_specifications.rb
+- spec/lib/given/extensions_spec.rb
+- spec/lib/given/failing_thens_spec.rb
+- spec/lib/given/failure_matcher_spec.rb
+- spec/lib/given/failure_spec.rb
+- spec/lib/given/file_cache_spec.rb
+- spec/lib/given/fuzzy_number_spec.rb
+- spec/lib/given/have_failed_spec.rb
+- spec/lib/given/lexical_purity_spec.rb
+- spec/lib/given/line_extractor_spec.rb
+- spec/lib/given/module_methods_spec.rb
+- spec/lib/given/natural_assertion_spec.rb
+- spec/lib/given/options_spec.rb
+- spec/spec_helper.rb
+- spec/support/be_booleany.rb
+- spec/support/failure_and_errors.rb
+- spec/support/faux_then.rb
+- spec/support/natural_assertion_control.rb
+- support
+homepage: http://github.com/rspec-given/rspec-given
+licenses:
+- MIT
+metadata: {}
+post_install_message: 
+rdoc_options:
+- "--line-numbers"
+- "--inline-source"
+- "--main"
+- doc/main.rdoc
+- "--title"
+- RSpec Given Extensions
+require_paths:
+- lib
+required_ruby_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: 1.9.2
+required_rubygems_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: '0'
+requirements: []
+rubyforge_project: given
+rubygems_version: 2.4.5.1
+signing_key: 
+specification_version: 4
+summary: Given/When/Then Specification Extensions for RSpec.
+test_files: []

--- a/spec/lib/given/assertions_spec.rb
+++ b/spec/lib/given/assertions_spec.rb
@@ -3,8 +3,6 @@ require 'rspec/given'
 require 'given/assertions'
 
 describe Given::Assertions do
-  use_natural_assertions_if_supported
-
   Given { extend Given::Assertions }
 
   describe "Assert { }" do

--- a/spec/lib/given/ext/numeric_spec.rb
+++ b/spec/lib/given/ext/numeric_spec.rb
@@ -4,7 +4,6 @@ require 'given'
 require 'given/fuzzy_shortcuts'
 
 describe "Numeric Extensions" do
-  use_natural_assertions_if_supported
 
   Given(:n) { 10 }
   Given(:about_n) { about(n) }

--- a/spec/lib/given/ext/numeric_specifications.rb
+++ b/spec/lib/given/ext/numeric_specifications.rb
@@ -4,7 +4,6 @@ require 'rspec/given'
 require 'rspec/given/fuzzy_shortcuts'
 
 describe "Numeric Extensions" do
-  use_natural_assertions_if_supported
 
   Given(:n) { 10 }
   Given(:about_n) { about(n) }

--- a/spec/lib/given/extensions_spec.rb
+++ b/spec/lib/given/extensions_spec.rb
@@ -190,15 +190,9 @@ describe Given::ClassExtensions do
 end
 
 describe "use_natural_assertions" do
-  context "when in JRuby" do
-    CONTEXT = self
+  CONTEXT = self
 
-    When(:result) { CONTEXT.use_natural_assertions }
+  When(:result) { CONTEXT.use_natural_assertions }
 
-    if ::Given::NATURAL_ASSERTIONS_SUPPORTED
-      Then { expect(result).to_not have_failed }
-    else
-      Then { expect(result).to have_failed(ArgumentError) }
-    end
-  end
+  Then { expect(result).to_not have_failed }
 end

--- a/spec/lib/given/failure_matcher_spec.rb
+++ b/spec/lib/given/failure_matcher_spec.rb
@@ -8,7 +8,6 @@ module FailureMatcherSpec
   NotMetError = RSpec::Expectations::ExpectationNotMetError
 
   describe Given::FailureMatcher do
-    use_natural_assertions_if_supported
 
     Given(:error) { CustomError.new("CUSTOM") }
 

--- a/spec/lib/given/failure_spec.rb
+++ b/spec/lib/given/failure_spec.rb
@@ -27,21 +27,18 @@ describe Given::Failure do
   end
 
   describe "== have_failed" do
-    use_natural_assertions_if_supported
     Then { failure == have_failed(StandardError, "Oops") }
     Then { failure == have_failed(StandardError) }
     Then { failure == have_failed }
   end
 
   describe "== Failure" do
-    use_natural_assertions_if_supported
     Then { failure == Failure(StandardError, "Oops") }
     Then { failure == Failure(StandardError) }
     Then { failure == Failure() }
   end
 
   describe "!= Failure" do
-    use_natural_assertions_if_supported
     Then { expect { failure != Object.new }.to raise_error(StandardError) }
     Then { failure != Failure(other_error) }
   end

--- a/spec/lib/given/fuzzy_number_spec.rb
+++ b/spec/lib/given/fuzzy_number_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Given::Fuzzy::FuzzyNumber do
-  use_natural_assertions_if_supported
   include Given::Fuzzy
 
   describe "attributes" do

--- a/spec/lib/given/have_failed_spec.rb
+++ b/spec/lib/given/have_failed_spec.rb
@@ -61,7 +61,6 @@ module HaveFailedSpec
     end
 
     context "with natural assertions" do
-      use_natural_assertions_if_supported
 
       context "with failure" do
         When(:result) { fail CustomError, "Ouch" }

--- a/spec/lib/given/lexical_purity_spec.rb
+++ b/spec/lib/given/lexical_purity_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 LEXICAL_PURITY_GLOBAL_CONSTANT = 3
 
 describe "Lexical Purity" do
-  use_natural_assertions_if_supported
 
   A = 1
   Given(:avalue) { 1 }

--- a/spec/lib/given/module_methods_spec.rb
+++ b/spec/lib/given/module_methods_spec.rb
@@ -1,13 +1,7 @@
 require 'spec_helper'
 
 describe "RSpec::Given.use_natural_assertions" do
-  context "when in JRuby" do
-    When(:result) { ::Given.use_natural_assertions }
+  When(:result) { ::Given.use_natural_assertions }
 
-    if ::Given::NATURAL_ASSERTIONS_SUPPORTED
-      Then { expect(result).to_not have_failed }
-    else
-      Then { expect(result).to have_failed(ArgumentError) }
-    end
-  end
+  Then { expect(result).to_not have_failed }
 end

--- a/spec/lib/given/natural_assertion_spec.rb
+++ b/spec/lib/given/natural_assertion_spec.rb
@@ -2,9 +2,6 @@ require 'rspec/given'
 require 'spec_helper'
 
 describe Given::NaturalAssertion do
-  before do
-    pending "Natural Assertions disabled for JRuby" unless Given::NATURAL_ASSERTIONS_SUPPORTED
-  end
 
   describe "#content?" do
     context "with empty block" do

--- a/spec/lib/given/options_spec.rb
+++ b/spec/lib/given/options_spec.rb
@@ -24,12 +24,6 @@ describe "Configuration Options" do
   end
 
   describe "Global natural assertion configuration" do
-    unless Given::NATURAL_ASSERTIONS_SUPPORTED
-      before do
-        pending "Natural assertions are not supported in JRuby"
-      end
-    end
-
     before do
       Given.use_natural_assertions false
     end
@@ -46,7 +40,7 @@ describe "Configuration Options" do
       Then { expect(_gvn_need_na_message?(nassert)).to be_falsy }
 
       context "overridden locally" do
-        use_natural_assertions_if_supported
+        use_natural_assertions
         Then { expect(_gvn_need_na_message?(nassert)).to be_truthy }
       end
     end
@@ -120,7 +114,7 @@ describe "Configuration Options" do
       Then { expect(_gvn_need_na_message?(nassert)).to be_falsy }
 
       context "overridden locally" do
-        use_natural_assertions_if_supported(true)
+        use_natural_assertions
         Then { expect(_gvn_need_na_message?(nassert)).to be_truthy }
       end
 

--- a/spec/support/natural_assertion_control.rb
+++ b/spec/support/natural_assertion_control.rb
@@ -1,15 +1,1 @@
-module NaturalAssertionControl
-  def use_natural_assertions_if_supported(enabled=true)
-    if enabled && ! Given::NATURAL_ASSERTIONS_SUPPORTED
-      Given {
-        pending "Natural assertions are not supported in JRuby"
-      }
-    else
-      use_natural_assertions(enabled)
-    end
-  end
-end
-
-RSpec.configure do |c|
-  c.extend(NaturalAssertionControl)
-end
+# NOTE: only here for backwards compatibility


### PR DESCRIPTION
This is a pragmatic approach to support natural assertions on Rubinius (and older versions of JRuby). From the updated README:

> If Ripper is not available, like on Rubinius and versions of JRuby prior to
> JRuby-1.7.5, detailed explanations of failures for natural assertions won't be
> available.  Natural assertions will still work, though.
> [...]
> # History
> - next release
>   - Natural assertions now work on Rubinius and older versions of JRuby (see [#15](https://github.com/rspec-given/rspec-given/issues/15))
>     - WARNING: On these platforms, detailed failure explanations aren't available and source code snippets of Then clauses will only show the first line.

This is all anybody needs who wants to run their specs on CI on a build matrix including Rubinius/JRuby. ;-)
