### PR TITLE
Fix failures in `failing_messages_spec.rb`.

### DIFF
--- a/examples/example_helper.rb
+++ b/examples/example_helper.rb
@@ -3,6 +3,15 @@ $LOAD_PATH << './examples/stack'
 if defined?(RSpec)
   require 'rspec/given'
   require 'spec_helper'
+
+  RSpec.configure do |config|
+    # Before RSpec 3.4, RSpec would only print lines in failures from spec files.
+    # Starting in 3.4, it now prints lines from the new `project_source_dirs` config
+    # setting. We want it to look for lines from our examples, and since its not the
+    # standard `spec` dir, we have to tell RSpec about it here.
+    # See #18 for more discussion.
+    config.project_source_dirs << "examples" if config.respond_to?(:project_source_dirs)
+  end
 else
   require 'minitest/autorun'
   require 'active_support_helper'

--- a/examples/integration/failing_messages_spec.rb
+++ b/examples/integration/failing_messages_spec.rb
@@ -7,7 +7,11 @@ describe "Failing Messages" do
   IOS = Struct.new(:out, :err)
 
   def run_spec(filename)
-    inn, out, err, wait = Open3.popen3("rspec", "examples/integration/failing/#{filename}")
+    _inn, out, err, _wait = Open3.popen3(
+      "rspec", "examples/integration/failing/#{filename}",
+      # Ensure our `project_source_dirs` config is set when we shell out to RSpec.
+      "-rexample_helper"
+    )
     IOS.new(out.read, err.read)
   end
 
@@ -52,7 +56,7 @@ describe "Failing Messages" do
 
   context "with an oddly formatted then" do
     Given(:failing_test) { "oddly_formatted_then.rb" }
-    Then { ios.out =~ /Failure\/Error: Then \{ result == \['a',$/ }
+    Then { ios.out =~ /Failure\/Error:\s*Then \{ result == \['a',$/ }
     And  { ios.out =~ /expected: "anything"/ }
     And  { ios.out =~ /to equal: \["a", "a"\]/ }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,12 @@
 require 'rspec/given'
+RSpec.configure do |config|
+  # Before RSpec 3.4, RSpec would only print lines in failures from spec files.
+  # Starting in 3.4, it now prints lines from the new `project_source_dirs` config
+  # setting. We want it to print lines from our specs instead of printing
+  # `::RSpec::Expectations.fail_with(*args)` from within lib/given/rspec/framework.rb,
+  # so we remove `lib` from the directories here.
+  config.project_source_dirs -= ["lib"] if config.respond_to?(:project_source_dirs)
+end
 
 # Load the support modules.
 


### PR DESCRIPTION
RSpec changed how it detects source lines to print in
rspec/rspec-core#2088, which necessitates us configuring
`project_source_dirs` for our specs. (This should not affect
end-users).

In addition, we now print multi-line code snippets as of
rspec/rspec-core#2083. Multiline snippets are not printed
on the same line as `Failure/Error:` so our regex has to
be updated to accommodate a line break.

Fixes #18.
