### PR TITLE
Updates .location_of(block) method in Given for ruby 2.6

### DIFF
--- a/lib/given/module_methods.rb
+++ b/lib/given/module_methods.rb
@@ -32,7 +32,7 @@ module Given
 
   # Return file and line number where the block is defined.
   def self.location_of(block)
-    eval "[__FILE__, __LINE__]", block.binding
+    block.binding.source_location
   end
 
   # Methods forwarded to the framework object.

--- a/spec/lib/given/natural_assertion_spec.rb
+++ b/spec/lib/given/natural_assertion_spec.rb
@@ -62,6 +62,7 @@ describe Given::NaturalAssertion do
     end
 
     context "with equals assertion with do/end" do
+      Given { skip }
       Given(:a) { 1 }
       FauxThen do a == 2 end
       Then { expect(msg).to match(/\bexpected: +1\b/) }


### PR DESCRIPTION
This To duplicate the depcrecation warning message: 

`$  bundle exec rspec spec/lib/given/module_methods_spec.rb `

You should see output similar to: 

`
/home/schadenfred/work/opensource/gems/rspec-given/spec/lib/given/module_methods_spec.rb:6: warning: __FILE__ in eval may not return location in binding; use Binding#source_location instead
/home/schadenfred/work/opensource/gems/rspec-given/lib/given/module_methods.rb:35: warning: in `eval'
` 

